### PR TITLE
chore: deprecate cmumaps-data submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "apps/data/cmumaps-data"]
-	path = apps/data/cmumaps-data
-	url = https://github.com/ScottyLabs/cmumaps-data


### PR DESCRIPTION
Deprecate cmumaps-data submodule to migrate to S3 bucket