### PR TITLE
feat: implement public building access for navigation and floor plans…

### DIFF
--- a/apps/web/src/components/floor-switcher/FloorSwitcher.tsx
+++ b/apps/web/src/components/floor-switcher/FloorSwitcher.tsx
@@ -5,6 +5,7 @@ import { useIsMobile } from "@/hooks/useIsMobile.ts";
 import { useUser } from "@/hooks/useUser.ts";
 import { CardStates } from "@/store/cardSlice";
 import { useBoundStore } from "@/store/index.ts";
+import { isPublicBuilding } from "@/utils/authUtils";
 
 /**
  * This component determines if the floor switcher should be shown.
@@ -29,8 +30,9 @@ const FloorSwitcher = () => {
   }
 
   // Don't show the floor switcher if the user is not signed in unless
-  // the floor is a CUC floor
-  if (!user && floor?.buildingCode !== "CUC") {
+  // the floor is a public building floor
+  const canViewFloor = Boolean(user) || isPublicBuilding(floor?.buildingCode);
+  if (!canViewFloor) {
     return;
   }
 

--- a/apps/web/src/components/map-display/floorplans-overlay/FloorplansOverlay.tsx
+++ b/apps/web/src/components/map-display/floorplans-overlay/FloorplansOverlay.tsx
@@ -1,14 +1,16 @@
 import { FloorplanOverlay } from "@/components/map-display/floorplans-overlay/FloorplanOverlay.tsx";
 import { useUser } from "@/hooks/useUser.ts";
 import { useBoundStore } from "@/store/index.ts";
+import { isPublicBuilding } from "@/utils/authUtils";
 
 const FloorplansOverlay = () => {
   const user = useUser();
   const focusedFloor = useBoundStore((state) => state.focusedFloor);
 
   // Authenticated users can see all floorplans.
-  // Unauthenticated users can only see CUC floorplans.
-  const canShowFloorplans = user || focusedFloor?.buildingCode === "CUC";
+  // Unauthenticated users can only see public building floorplans.
+  const canShowFloorplans =
+    user || isPublicBuilding(focusedFloor?.buildingCode);
 
   // Only show floorplans if a floor is focused
   if (!(focusedFloor && canShowFloorplans)) {

--- a/apps/web/src/components/toolbar/SearchResults.tsx
+++ b/apps/web/src/components/toolbar/SearchResults.tsx
@@ -12,6 +12,7 @@ import { useNavPaths } from "@/hooks/useNavigationParams.ts";
 import { useUser } from "@/hooks/useUser.ts";
 import { CardStates } from "@/store/cardSlice";
 import { useBoundStore } from "@/store/index.ts";
+import { isPublicBuilding } from "@/utils/authUtils";
 import { getFloorLevelFromRoomName } from "@/utils/floorUtils";
 import { zoomOnObject, zoomOnPoint } from "@/utils/zoomUtils";
 
@@ -249,7 +250,12 @@ const SearchResults = ({ searchQuery, mapRef }: Props) => {
 
   const handleClick = (result: SearchResultProps) => {
     if (result.type === "room") {
-      if (!user) {
+      // Public buildings are accessible to unauthenticated users via the public pathfinding API
+      // Other rooms require authentication
+      // Extract building code from nameWithSpace (e.g., "CUC 159" -> "CUC")
+      const buildingCode = result.nameWithSpace?.split(" ")[0];
+      const canAccess = Boolean(user) || isPublicBuilding(buildingCode);
+      if (!canAccess) {
         showLogin();
         return;
       }

--- a/apps/web/src/hooks/useMapRegionChange.ts
+++ b/apps/web/src/hooks/useMapRegionChange.ts
@@ -10,6 +10,7 @@ import {
 } from "@/components/map-display/mapConstants";
 import { useMapPosition } from "@/hooks/useMapPosition.ts";
 import { useBoundStore } from "@/store";
+import { isPublicBuilding } from "@/utils/authUtils";
 import {
   getFloorByOrdinal,
   getFloorLevelFromRoomName,
@@ -134,11 +135,12 @@ const useMapRegionChange = (mapRef: RefObject<mapkit.Map | null>) => {
         const newFocusedFloor = calcFocusedFloor(region);
 
         // Show the login modal if the user is not signed in and we are showing a floor
-        // Exception: we are allowed to show CUC floors to all users
-        if (
-          !(sessionStorage.getItem("showedLogin") || user) &&
-          newFocusedFloor?.buildingCode !== "CUC"
-        ) {
+        // Exception: we are allowed to show public building floors to all users
+        const canSkipLogin =
+          sessionStorage.getItem("showedLogin") ||
+          user ||
+          isPublicBuilding(newFocusedFloor?.buildingCode);
+        if (!canSkipLogin) {
           sessionStorage.setItem("showedLogin", "true");
           showLogin();
           return;

--- a/apps/web/src/utils/authUtils.ts
+++ b/apps/web/src/utils/authUtils.ts
@@ -7,3 +7,21 @@ export const signIn = () => {
 export const signOut = () => {
   window.location.href = `${env.VITE_SERVER_URL}/logout?redirect_uri=${window.location.href}`;
 };
+
+/**
+ * Building codes that are publicly accessible without authentication.
+ * Currently only CUC (Cohon University Center) is publicly accessible.
+ */
+const PUBLIC_BUILDING_CODES = ["CUC"];
+
+/**
+ * Checks if a building is publicly accessible without authentication.
+ * @param buildingCode - The building code to check
+ * @returns true if the building is publicly accessible
+ */
+export const isPublicBuilding = (
+  buildingCode: string | undefined | null,
+): boolean => {
+  if (!buildingCode) return false;
+  return PUBLIC_BUILDING_CODES.includes(buildingCode);
+};


### PR DESCRIPTION
… for web

- Added `isPublicBuilding` utility to check if a building is publicly accessible.
- Updated navigation hooks and components to allow unauthenticated users access to public buildings.
- Modified floor switcher and floor plans overlay to reflect public access rules.
- Enhanced search results handling for room access based on building code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now view certain public buildings, floorplans, and access navigation features without authentication, enabling broader accessibility across the application.

* **Chores**
  * Refactored access control system to support granular, building-based visibility rules across map display, search, and navigation components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->