### PR TITLE
Post-login URL parameters

### DIFF
--- a/apps/web/src/components/login/LoginModal.tsx
+++ b/apps/web/src/components/login/LoginModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useNavPaths } from "@/hooks/useNavigationParams.ts";
 import { useUser } from "@/hooks/useUser.ts";
-import { signIn } from "@/lib/authClient.ts";
+import { clearPostLoginCallbackUrl, signIn } from "@/lib/authClient.ts";
 import { useBoundStore } from "@/store/index.ts";
 
 const LoginModal = () => {
@@ -51,6 +51,7 @@ const LoginModal = () => {
             type="button"
             className="cursor-pointer rounded-md bg-red-200 p-2 text-red-700 text-sm hover:bg-red-300"
             onClick={() => {
+              clearPostLoginCallbackUrl();
               hideLogin();
               setSrc(null);
               setDst(null);

--- a/apps/web/src/components/toolbar/SearchResults.tsx
+++ b/apps/web/src/components/toolbar/SearchResults.tsx
@@ -11,6 +11,7 @@ import stairsIcon from "@/assets/icons/search_results/stairs.svg";
 import { useNavigateLocationParams } from "@/hooks/useNavigateLocationParams.ts";
 import { useNavPaths } from "@/hooks/useNavigationParams.ts";
 import { useUser } from "@/hooks/useUser.ts";
+import { setPostLoginCallbackUrl } from "@/lib/authClient.ts";
 import { CardStates } from "@/store/cardSlice";
 import { useBoundStore } from "@/store/index.ts";
 import { isPublicBuilding } from "@/utils/authUtils";
@@ -317,12 +318,25 @@ const SearchResults = ({ searchQuery, mapRef }: Props) => {
     if (result.type === "room" || result.type === "floor") {
       // Public buildings are accessible to unauthenticated users via the public pathfinding API
       // Other indoor destinations require authentication
+      const [nameBuildingCode, roomName] =
+        result.nameWithSpace?.split(" ") ?? [];
       const buildingCode =
         result.type === "floor"
           ? (result.floor?.buildingCode ?? result.id.split("-")[0])
-          : result.nameWithSpace?.split(" ")[0];
+          : nameBuildingCode;
       const canAccess = Boolean(user) || isPublicBuilding(buildingCode);
       if (!canAccess) {
+        const callbackPath =
+          result.type === "floor"
+            ? `/${result.id}`
+            : buildingCode && roomName
+              ? `/${buildingCode}-${roomName}`
+              : null;
+        if (callbackPath) {
+          const callbackUrl = new URL(window.location.href);
+          callbackUrl.pathname = callbackPath;
+          setPostLoginCallbackUrl(callbackUrl.toString());
+        }
         showLogin();
         return;
       }

--- a/apps/web/src/lib/authClient.ts
+++ b/apps/web/src/lib/authClient.ts
@@ -6,12 +6,54 @@ const auth = createAuthClient({
   // biome-ignore lint/style/useNamingConvention: defined by better-auth
   baseURL: env.VITE_SERVER_URL,
 });
+
+const POST_LOGIN_CALLBACK_URL_KEY = "postLoginCallbackURL";
+
+const sanitizeCallbackUrl = (callbackUrl: string): string => {
+  try {
+    const parsedCallbackUrl = new URL(callbackUrl, window.location.origin);
+    if (parsedCallbackUrl.origin !== window.location.origin) {
+      return window.location.href;
+    }
+    return parsedCallbackUrl.toString();
+  } catch {
+    return window.location.href;
+  }
+};
+
+const consumePostLoginCallbackUrl = (): string | null => {
+  const postLoginCallbackUrl = sessionStorage.getItem(
+    POST_LOGIN_CALLBACK_URL_KEY,
+  );
+  if (!postLoginCallbackUrl) {
+    return null;
+  }
+
+  sessionStorage.removeItem(POST_LOGIN_CALLBACK_URL_KEY);
+  return postLoginCallbackUrl;
+};
+
+export const setPostLoginCallbackUrl = (callbackUrl: string) => {
+  sessionStorage.setItem(
+    POST_LOGIN_CALLBACK_URL_KEY,
+    sanitizeCallbackUrl(callbackUrl),
+  );
+};
+
+export const clearPostLoginCallbackUrl = () => {
+  sessionStorage.removeItem(POST_LOGIN_CALLBACK_URL_KEY);
+};
+
 export const signIn = () => {
+  const callbackUrl = sanitizeCallbackUrl(
+    consumePostLoginCallbackUrl() ?? window.location.href,
+  );
+
   auth.signIn
     .social({
       provider: "keycloak",
       // biome-ignore lint/style/useNamingConvention: defined by better-auth
-      callbackURL: window.location.href,
+      callbackURL: callbackUrl,
     })
     .then((result) => {
       if (result.error) {


### PR DESCRIPTION
Preserve URL parameters after login to maintain room focus.

Previously, clicking a protected room while logged out opened the login modal without storing the intended destination, causing the post-login redirect to lose the room search parameters. This PR stores the intended callback URL before login and uses it after successful authentication.

---
<p><a href="https://cursor.com/agents/bc-4c71b9db-7e65-4b87-9a39-6ed0277a91f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c71b9db-7e65-4b87-9a39-6ed0277a91f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

