### PR TITLE
Floor switcher lock indicator

### DIFF
--- a/apps/web/src/components/floor-switcher/desktop/FloorSwitcherDisplayDesktop.tsx
+++ b/apps/web/src/components/floor-switcher/desktop/FloorSwitcherDisplayDesktop.tsx
@@ -2,6 +2,7 @@ import type { Building, Floor } from "@cmumaps/common";
 import { useState } from "react";
 import { DefaultView } from "@/components/floor-switcher/desktop/DefaultView";
 import { FloorPicker } from "@/components/floor-switcher/desktop/FloorPicker";
+import { LockedView } from "@/components/floor-switcher/desktop/LockedView";
 import { RoundelButton } from "@/components/floor-switcher/desktop/RoundelButton";
 
 interface Props {
@@ -11,22 +12,27 @@ interface Props {
 
 const FloorSwitcherDisplayDesktop = ({ building, floor }: Props) => {
   const [showFloorPicker, setShowFloorPicker] = useState<boolean>(false);
+  const hasFloorplan = building.floors.length > 0;
 
   return (
     <div className="btn-shadow flex rounded bg-white">
       <RoundelButton building={building} />
-      {showFloorPicker ? (
-        <FloorPicker
-          building={building}
-          floor={floor}
-          setShowFloorPicker={setShowFloorPicker}
-        />
+      {hasFloorplan ? (
+        showFloorPicker ? (
+          <FloorPicker
+            building={building}
+            floor={floor}
+            setShowFloorPicker={setShowFloorPicker}
+          />
+        ) : (
+          <DefaultView
+            building={building}
+            floor={floor}
+            setShowFloorPicker={setShowFloorPicker}
+          />
+        )
       ) : (
-        <DefaultView
-          building={building}
-          floor={floor}
-          setShowFloorPicker={setShowFloorPicker}
-        />
+        <LockedView building={building} />
       )}
     </div>
   );

--- a/apps/web/src/components/floor-switcher/desktop/LockedView.tsx
+++ b/apps/web/src/components/floor-switcher/desktop/LockedView.tsx
@@ -8,9 +8,8 @@ interface Props {
 const LockedView = ({ building }: Props) => (
   <div className="flex items-center">
     <p className="mr-4 ml-2">{building.name}</p>
-    <div className="flex items-center gap-1 rounded-r bg-gray-200 py-2 pr-1">
+    <div className="flex items-center rounded-r bg-gray-200 p-2">
       <img alt="Lock Icon" src={lockIcon} />
-      <p className="p-1 text-[#646464]">Inaccessible</p>
     </div>
   </div>
 );

--- a/apps/web/src/components/floor-switcher/mobile/FloorSwitcherDisplayMobile.tsx
+++ b/apps/web/src/components/floor-switcher/mobile/FloorSwitcherDisplayMobile.tsx
@@ -2,6 +2,7 @@ import type { Building } from "@cmumaps/common";
 import { animate, motion, useMotionValue } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { $api } from "@/api/client";
+import lockIcon from "@/assets/icons/half-lock.svg";
 import { useBoundStore } from "@/store/index.ts";
 import { FloorSwitcherCarouselMobile } from "./FloorSwitcherCarouselMobile.tsx";
 
@@ -13,6 +14,7 @@ interface Props {
 const FloorSwitcherDisplayMobile = ({ building, initialFloorLevel }: Props) => {
   const focusFloor = useBoundStore((state) => state.focusFloor);
   const searchTarget = useBoundStore((state) => state.searchTarget);
+  const hasFloorplan = building.floors.length > 0;
   const floorIndex = building.floors.indexOf(initialFloorLevel);
 
   const draggableRegionRef = useRef<HTMLDivElement>(null);
@@ -88,6 +90,17 @@ const FloorSwitcherDisplayMobile = ({ building, initialFloorLevel }: Props) => {
 
   if (searchTarget) {
     return;
+  }
+
+  if (!hasFloorplan) {
+    return (
+      <div className="fixed top-1/2 flex h-78 w-68 -translate-x-1/2 -translate-y-1/2 items-center justify-center align-center">
+        <div className="btn-shadow flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-[#646464] backdrop-blur-md">
+          <img alt="Lock Icon" src={lockIcon} />
+          <p>Inaccessible</p>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/apps/web/src/components/floor-switcher/mobile/FloorSwitcherDisplayMobile.tsx
+++ b/apps/web/src/components/floor-switcher/mobile/FloorSwitcherDisplayMobile.tsx
@@ -95,9 +95,8 @@ const FloorSwitcherDisplayMobile = ({ building, initialFloorLevel }: Props) => {
   if (!hasFloorplan) {
     return (
       <div className="fixed top-1/2 flex h-78 w-68 -translate-x-1/2 -translate-y-1/2 items-center justify-center align-center">
-        <div className="btn-shadow flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-[#646464] backdrop-blur-md">
+        <div className="btn-shadow flex items-center justify-center rounded-full bg-white/80 p-3 backdrop-blur-md">
           <img alt="Lock Icon" src={lockIcon} />
-          <p>Inaccessible</p>
         </div>
       </div>
     );

--- a/apps/web/src/hooks/useMapRegionChange.ts
+++ b/apps/web/src/hooks/useMapRegionChange.ts
@@ -99,8 +99,8 @@ const useMapRegionChange = (mapRef: RefObject<mapkit.Map | null>) => {
 
       return {
         buildingCode: centerBuilding.code,
-        // biome-ignore lint/style/noNonNullAssertion: TODO: figure out which floor to focus on if no default floor is set
-        level: centerBuilding.defaultFloor!,
+        // Fallback to the first known floor if default metadata is missing.
+        level: centerBuilding.defaultFloor ?? centerBuilding.floors[0] ?? "",
       };
     }
 


### PR DESCRIPTION
Implement a lock indicator on the floor switcher for buildings without floorplans to resolve issue #233.

The floor switcher now displays a lock icon (desktop) or badge (mobile) when a selected building has no associated floor levels, providing clear visual feedback instead of an empty or confusing UI. This change also hardens floor focusing logic to prevent issues with buildings lacking default floor levels.

---
<p><a href="https://cursor.com/agents/bc-a95375ef-aa85-4e9b-935a-7efeb16f6c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a95375ef-aa85-4e9b-935a-7efeb16f6c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

