### PR TITLE
feat: Collapse draggable sheet when mobile user drag the map

### DIFF
--- a/apps/web/src/components/info-cards/building-card/BuildingCard.tsx
+++ b/apps/web/src/components/info-cards/building-card/BuildingCard.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const BuildingCard = ({ mapRef: _mapRef }: Props) => {
   const isMobile = useIsMobile();
-  const isCardCollapsed = useBoundStore((state) => state.isCardCollapsed)();
+  const isCardCollapsed = useBoundStore((state) => state.isCardCollapsed());
   const { buildingCode } = useLocationParams();
   const { data: buildings } = $api.useQuery("get", "/buildings");
 

--- a/apps/web/src/components/info-cards/room-card/RoomCard.tsx
+++ b/apps/web/src/components/info-cards/room-card/RoomCard.tsx
@@ -7,7 +7,7 @@ import { useBoundStore } from "@/store/index.ts";
 
 const RoomCard = () => {
   const isMobile = useIsMobile();
-  const isCardCollapsed = useBoundStore((state) => state.isCardCollapsed)();
+  const isCardCollapsed = useBoundStore((state) => state.isCardCollapsed());
   const { buildingCode, roomName, floor } = useLocationParams();
 
   // Query data

--- a/apps/web/src/components/info-cards/wrapper/DraggableSheet.tsx
+++ b/apps/web/src/components/info-cards/wrapper/DraggableSheet.tsx
@@ -43,14 +43,13 @@ const DraggableSheet = ({
 
   // updates the card status when the isCardOpen changes
   // TODO: uncomment once eateries are listed
-  // biome-ignore lint/correctness/useExhaustiveDependencies: will change once eateries are listed
   useEffect(() => {
-    // if (isCardOpen && !floor && !focusedFloor && !coordinate) {
-    //   setCardStatus(CardStates.HALF_OPEN);
-    // } else {
-    //   setCardStatus(CardStates.COLLAPSED);
-    // }
-    setCardStatus(CardStates.COLLAPSED);
+    if (isCardOpen && !floor && !focusedFloor && !coordinate) {
+      setCardStatus(CardStates.HALF_OPEN);
+    } else {
+      setCardStatus(CardStates.COLLAPSED);
+    }
+    // setCardStatus(CardStates.COLLAPSED);
   }, [isCardOpen, setCardStatus, floor, focusedFloor, coordinate]);
 
   // updates the snapping when isCardOpen or snapIndex changes

--- a/apps/web/src/components/map-display/MapDisplay.tsx
+++ b/apps/web/src/components/map-display/MapDisplay.tsx
@@ -12,6 +12,7 @@ import { useLocationParams } from "@/hooks/useLocationParams.ts";
 import { useMapRegionChange } from "@/hooks/useMapRegionChange.ts";
 import { useNavigateLocationParams } from "@/hooks/useNavigateLocationParams.ts";
 import { useNavPaths } from "@/hooks/useNavigationParams.ts";
+import { CardStates } from "@/store/cardSlice.ts";
 import { useBoundStore } from "@/store/index.ts";
 import { buildFloorCode, getFloorLevelFromRoomName } from "@/utils/floorUtils";
 import { isInPolygon } from "@/utils/geometry";
@@ -32,6 +33,7 @@ const MapDisplay = ({ mapRef }: Props) => {
   const hideSearch = useBoundStore((state) => state.hideSearch);
   const selectBuilding = useBoundStore((state) => state.selectBuilding);
   const deselectBuilding = useBoundStore((state) => state.deselectBuilding);
+  const setCardStatus = useBoundStore((state) => state.setCardStatus);
   const setIsZooming = useBoundStore((state) => state.setIsZooming);
   const queuedZoomRegion = useBoundStore((state) => state.queuedZoomRegion);
   const setQueuedZoomRegion = useBoundStore(
@@ -176,7 +178,10 @@ const MapDisplay = ({ mapRef }: Props) => {
       onLoad={handleLoad}
       onClick={handleClick}
       onLongPress={handleLongPress}
-      onRegionChangeStart={onRegionChangeStart}
+      onRegionChangeStart={() => {
+        setCardStatus(CardStates.COLLAPSED);
+        onRegionChangeStart();
+      }}
       onRegionChangeEnd={() => {
         if (queuedZoomRegion) {
           mapRef.current?.setRegionAnimated(


### PR DESCRIPTION
These changes will collapse the draggable sheet when mobile users drag or zoom the map.

Also I've fixed the bug where refreshing with a building code URL doesn't show the picture. And collapsing the draggable sheet will still show half of the building picture.