### PR TITLE
feat: Added draggable booth card

### DIFF
--- a/apps/web/src/components/booth-cards/BoothCard.tsx
+++ b/apps/web/src/components/booth-cards/BoothCard.tsx
@@ -1,0 +1,124 @@
+import { HiOutlineMap } from "react-icons/hi2";
+import boothData from "@/assets/carnival/json/booth.json" with { type: "json" };
+import { ButtonsRow } from "@/components/info-cards/shared/buttons-row/ButtonsRow";
+import { InfoCardImage } from "@/components/info-cards/shared/media/InfoCardImage.tsx";
+import type { CardStatus } from "@/store/cardSlice.ts";
+import { CardStates } from "@/store/cardSlice.ts";
+
+interface Props {
+  cardStatus: CardStatus;
+}
+
+interface BoothInfo {
+  boothType: string;
+  orgType: string;
+  theme: string;
+}
+
+const TAG_STYLES: Record<string, string> = {
+  club: "bg-[#DDEEFF] text-[#0093E0]",
+  fraternity: "bg-[#E4D7FA] text-[#5B3CB7]",
+  sorority: "bg-[#FFE3D7] text-[#E35A1C]",
+};
+
+const BoothCard = ({ cardStatus }: Props) => {
+  const isCollapsed = cardStatus === CardStates.COLLAPSED;
+  const isExpanded = cardStatus === CardStates.EXPANDED;
+  const showImage = !isCollapsed;
+  const showBoothList = !isCollapsed;
+  const showDescription = isExpanded;
+  const showViewAllButton = !isExpanded;
+
+  const booths = Object.entries(boothData as Record<string, BoothInfo>);
+
+  const renderBadge = (label: string, className: string) => (
+    <span className={`rounded-md px-2 py-1 font-bold text-sm ${className}`}>
+      {label}
+    </span>
+  );
+
+  const renderBoothItem = (
+    [name, booth]: [string, BoothInfo],
+    index: number,
+    horizontal: boolean,
+  ) => (
+    <article
+      key={`${name}-${index}`}
+      className={`rounded-2xl border border-stroke-neutral-1 bg-white p-3 shadow-sm ${horizontal ? "min-w-[300px]" : ""}`}
+    >
+      <div className="mb-2 flex gap-2">
+        {renderBadge(booth.boothType, "bg-[#FFE3D7] text-[#E35A1C]")}
+        {renderBadge(
+          booth.orgType,
+          TAG_STYLES[booth.orgType.toLowerCase()] ??
+            "bg-gray-100 text-gray-700",
+        )}
+      </div>
+      <h3 className="leading-tight">{name}</h3>
+      <p className="mt-1 text-gray-500">Theme: {booth.theme}</p>
+    </article>
+  );
+
+  const renderMiddleButton = () => (
+    <button
+      type="button"
+      className="flex items-center gap-2 rounded-full bg-primary-red px-5 py-2 text-white"
+    >
+      <HiOutlineMap size={16} />
+      <span>View all booth</span>
+    </button>
+  );
+
+  const renderBoothList = () => {
+    if (isExpanded) {
+      return (
+        <div className="space-y-4 px-3 py-4">
+          {booths.map((entry, index) => renderBoothItem(entry, index, false))}
+        </div>
+      );
+    }
+
+    return (
+      <div className="no-scrollbar flex gap-3 overflow-x-auto px-3 py-4">
+        {booths.map((entry, index) => renderBoothItem(entry, index, true))}
+      </div>
+    );
+  };
+
+  const renderDescription = () => (
+    <div className="px-3 py-4 text-gray-900">
+      Booth is one of the biggest showcases of Spring Carnival. Student
+      organizations build multi-story structures around their chosen theme.
+      These booths include interactive games and elaborate decorations. The
+      booths are located on Midway, at the College of Fine Arts parking lot.
+      Admission is free to see booths.
+    </div>
+  );
+
+  return (
+    <>
+      {showImage ? (
+        <InfoCardImage url="/imgs/carnival/booth.png" alt="Booth" />
+      ) : null}
+      <div className="mx-3 mt-2">
+        <h2>Booth</h2>
+        <p className="text-gray-500">Midway</p>
+      </div>
+      <ButtonsRow
+        middleButton={showViewAllButton ? renderMiddleButton() : undefined}
+      />
+      {showBoothList ? (
+        <div className="border-stroke-neutral-1 border-t" />
+      ) : null}
+      {showDescription ? (
+        <>
+          {renderDescription()}
+          <div className="border-stroke-neutral-1 border-t" />
+        </>
+      ) : null}
+      {showBoothList ? renderBoothList() : null}
+    </>
+  );
+};
+
+export { BoothCard };

--- a/apps/web/src/components/booth-cards/BoothCard.tsx
+++ b/apps/web/src/components/booth-cards/BoothCard.tsx
@@ -1,5 +1,6 @@
 import { HiOutlineMap } from "react-icons/hi2";
 import boothData from "@/assets/carnival/json/booth.json" with { type: "json" };
+import { BoothEventCard } from "@/components/booth-cards/BoothEventCard.tsx";
 import { ButtonsRow } from "@/components/info-cards/shared/buttons-row/ButtonsRow";
 import { InfoCardImage } from "@/components/info-cards/shared/media/InfoCardImage.tsx";
 import type { CardStatus } from "@/store/cardSlice.ts";
@@ -15,12 +16,6 @@ interface BoothInfo {
   theme: string;
 }
 
-const TAG_STYLES: Record<string, string> = {
-  club: "bg-[#DDEEFF] text-[#0093E0]",
-  fraternity: "bg-[#E4D7FA] text-[#5B3CB7]",
-  sorority: "bg-[#FFE3D7] text-[#E35A1C]",
-};
-
 const BoothCard = ({ cardStatus }: Props) => {
   const isCollapsed = cardStatus === CardStates.COLLAPSED;
   const isExpanded = cardStatus === CardStates.EXPANDED;
@@ -30,34 +25,6 @@ const BoothCard = ({ cardStatus }: Props) => {
   const showViewAllButton = !isExpanded;
 
   const booths = Object.entries(boothData as Record<string, BoothInfo>);
-
-  const renderBadge = (label: string, className: string) => (
-    <span className={`rounded-md px-2 py-1 font-bold text-sm ${className}`}>
-      {label}
-    </span>
-  );
-
-  const renderBoothItem = (
-    [name, booth]: [string, BoothInfo],
-    index: number,
-    horizontal: boolean,
-  ) => (
-    <article
-      key={`${name}-${index}`}
-      className={`rounded-2xl border border-stroke-neutral-1 bg-white p-3 shadow-sm ${horizontal ? "min-w-[300px]" : ""}`}
-    >
-      <div className="mb-2 flex gap-2">
-        {renderBadge(booth.boothType, "bg-[#FFE3D7] text-[#E35A1C]")}
-        {renderBadge(
-          booth.orgType,
-          TAG_STYLES[booth.orgType.toLowerCase()] ??
-            "bg-gray-100 text-gray-700",
-        )}
-      </div>
-      <h3 className="leading-tight">{name}</h3>
-      <p className="mt-1 text-gray-500">Theme: {booth.theme}</p>
-    </article>
-  );
 
   const renderMiddleButton = () => (
     <button
@@ -73,14 +40,32 @@ const BoothCard = ({ cardStatus }: Props) => {
     if (isExpanded) {
       return (
         <div className="space-y-4 px-3 py-4">
-          {booths.map((entry, index) => renderBoothItem(entry, index, false))}
+          {booths.map(([name, booth]) => (
+            <BoothEventCard
+              boothType={booth.boothType}
+              horizontal={false}
+              key={name}
+              name={name}
+              orgType={booth.orgType}
+              theme={booth.theme}
+            />
+          ))}
         </div>
       );
     }
 
     return (
       <div className="no-scrollbar flex gap-3 overflow-x-auto px-3 py-4">
-        {booths.map((entry, index) => renderBoothItem(entry, index, true))}
+        {booths.map(([name, booth]) => (
+          <BoothEventCard
+            boothType={booth.boothType}
+            horizontal={true}
+            key={name}
+            name={name}
+            orgType={booth.orgType}
+            theme={booth.theme}
+          />
+        ))}
       </div>
     );
   };

--- a/apps/web/src/components/booth-cards/BoothCard.tsx
+++ b/apps/web/src/components/booth-cards/BoothCard.tsx
@@ -5,6 +5,7 @@ import { ButtonsRow } from "@/components/info-cards/shared/buttons-row/ButtonsRo
 import { InfoCardImage } from "@/components/info-cards/shared/media/InfoCardImage.tsx";
 import type { CardStatus } from "@/store/cardSlice.ts";
 import { CardStates } from "@/store/cardSlice.ts";
+import { useBoundStore } from "@/store/index.ts";
 
 interface Props {
   cardStatus: CardStatus;
@@ -19,6 +20,7 @@ interface BoothInfo {
 const BoothCard = ({ cardStatus }: Props) => {
   const isCollapsed = cardStatus === CardStates.COLLAPSED;
   const isExpanded = cardStatus === CardStates.EXPANDED;
+  const setCardStatus = useBoundStore((state) => state.setCardStatus);
   const showImage = !isCollapsed;
   const showBoothList = !isCollapsed;
   const showDescription = isExpanded;
@@ -30,6 +32,7 @@ const BoothCard = ({ cardStatus }: Props) => {
     <button
       type="button"
       className="flex items-center gap-2 rounded-full bg-primary-red px-5 py-2 text-white"
+      onClick={() => setCardStatus(CardStates.EXPANDED)}
     >
       <HiOutlineMap size={16} />
       <span>View all booth</span>
@@ -55,7 +58,7 @@ const BoothCard = ({ cardStatus }: Props) => {
     }
 
     return (
-      <div className="no-scrollbar flex gap-3 overflow-x-auto px-3 py-4">
+      <div className="no-scrollbar flex items-start gap-3 overflow-x-auto px-3 pt-4 pb-0">
         {booths.map(([name, booth]) => (
           <BoothEventCard
             boothType={booth.boothType}

--- a/apps/web/src/components/booth-cards/BoothCard.tsx
+++ b/apps/web/src/components/booth-cards/BoothCard.tsx
@@ -1,4 +1,5 @@
 import { HiOutlineMap } from "react-icons/hi2";
+import { useNavigate } from "react-router";
 import boothData from "@/assets/carnival/json/booth.json" with { type: "json" };
 import { BoothEventCard } from "@/components/booth-cards/BoothEventCard.tsx";
 import { ButtonsRow } from "@/components/info-cards/shared/buttons-row/ButtonsRow";
@@ -18,6 +19,7 @@ interface BoothInfo {
 }
 
 const BoothCard = ({ cardStatus }: Props) => {
+  const navigate = useNavigate();
   const isCollapsed = cardStatus === CardStates.COLLAPSED;
   const isExpanded = cardStatus === CardStates.EXPANDED;
   const setCardStatus = useBoundStore((state) => state.setCardStatus);
@@ -39,6 +41,13 @@ const BoothCard = ({ cardStatus }: Props) => {
     </button>
   );
 
+  const openSpecificBooth = (boothName: string) => {
+    setCardStatus(CardStates.HALF_OPEN);
+    Promise.resolve(
+      navigate(`/carnival/booth/${encodeURIComponent(boothName)}`),
+    ).catch(() => undefined);
+  };
+
   const renderBoothList = () => {
     if (isExpanded) {
       return (
@@ -49,6 +58,7 @@ const BoothCard = ({ cardStatus }: Props) => {
               horizontal={false}
               key={name}
               name={name}
+              onClick={() => openSpecificBooth(name)}
               orgType={booth.orgType}
               theme={booth.theme}
             />
@@ -65,6 +75,7 @@ const BoothCard = ({ cardStatus }: Props) => {
             horizontal={true}
             key={name}
             name={name}
+            onClick={() => openSpecificBooth(name)}
             orgType={booth.orgType}
             theme={booth.theme}
           />

--- a/apps/web/src/components/booth-cards/BoothEventCard.tsx
+++ b/apps/web/src/components/booth-cards/BoothEventCard.tsx
@@ -1,0 +1,45 @@
+interface Props {
+  boothType: string;
+  horizontal: boolean;
+  name: string;
+  orgType: string;
+  theme: string;
+}
+
+const ORG_TAG_STYLES: Record<string, string> = {
+  club: "bg-[#DDEEFF] text-[#0093E0]",
+  fraternity: "bg-[#E4D7FA] text-[#5B3CB7]",
+  sorority: "bg-[#FFE3D7] text-[#E35A1C]",
+};
+
+const BoothEventCard = ({
+  boothType,
+  horizontal,
+  name,
+  orgType,
+  theme,
+}: Props) => {
+  const renderBadge = (label: string, className: string) => (
+    <span className={`rounded-md px-2 py-1 font-bold text-sm ${className}`}>
+      {label}
+    </span>
+  );
+
+  return (
+    <article
+      className={`rounded-2xl border border-stroke-neutral-1 bg-white p-3 shadow-sm ${horizontal ? "min-w-[300px]" : ""}`}
+    >
+      <div className="mb-2 flex gap-2">
+        {renderBadge(boothType, "bg-[#FFE3D7] text-[#E35A1C]")}
+        {renderBadge(
+          orgType,
+          ORG_TAG_STYLES[orgType.toLowerCase()] ?? "bg-gray-100 text-gray-700",
+        )}
+      </div>
+      <h3 className="leading-tight">{name}</h3>
+      <p className="mt-1 text-gray-500">Theme: {theme}</p>
+    </article>
+  );
+};
+
+export { BoothEventCard };

--- a/apps/web/src/components/booth-cards/BoothEventCard.tsx
+++ b/apps/web/src/components/booth-cards/BoothEventCard.tsx
@@ -2,6 +2,7 @@ interface Props {
   boothType: string;
   horizontal: boolean;
   name: string;
+  onClick: () => void;
   orgType: string;
   theme: string;
 }
@@ -16,18 +17,32 @@ const BoothEventCard = ({
   boothType,
   horizontal,
   name,
+  onClick,
   orgType,
   theme,
 }: Props) => {
+  const shouldUseWideLayout = horizontal && theme.length > 22;
+  const badgeClassName = "rounded-md px-2 py-1 font-bold text-sm ";
+  const cardWidthClass = horizontal
+    ? shouldUseWideLayout
+      ? "w-[344px] min-w-[344px]"
+      : "w-[300px] min-w-[300px]"
+    : "block w-full";
+
   const renderBadge = (label: string, className: string) => (
-    <span className={`rounded-md px-2 py-1 font-bold text-sm ${className}`}>
-      {label}
-    </span>
+    <span className={badgeClassName + className}>{label}</span>
   );
 
   return (
-    <article
-      className={`rounded-2xl border border-stroke-neutral-1 bg-white p-3 shadow-sm ${horizontal ? "min-w-[300px]" : ""}`}
+    <button
+      type="button"
+      className={[
+        "rounded-2xl border border-stroke-neutral-1 bg-white p-3 text-left shadow-sm",
+        cardWidthClass,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      onClick={onClick}
     >
       <div className="mb-2 flex gap-2">
         {renderBadge(boothType, "bg-[#FFE3D7] text-[#E35A1C]")}
@@ -38,7 +53,7 @@ const BoothEventCard = ({
       </div>
       <h3 className="leading-tight">{name}</h3>
       <p className="mt-1 text-gray-500">Theme: {theme}</p>
-    </article>
+    </button>
   );
 };
 

--- a/apps/web/src/components/booth-cards/SpecificBoothCard.tsx
+++ b/apps/web/src/components/booth-cards/SpecificBoothCard.tsx
@@ -1,0 +1,87 @@
+import { HiOutlineMap } from "react-icons/hi2";
+import { useNavigate } from "react-router";
+import boothData from "@/assets/carnival/json/booth.json" with { type: "json" };
+import { ButtonsRow } from "@/components/info-cards/shared/buttons-row/ButtonsRow";
+import { InfoCardImage } from "@/components/info-cards/shared/media/InfoCardImage.tsx";
+import type { CardStatus } from "@/store/cardSlice.ts";
+import { CardStates } from "@/store/cardSlice.ts";
+import { useBoundStore } from "@/store/index.ts";
+
+interface Props {
+  boothName: string;
+  cardStatus: CardStatus;
+}
+
+interface BoothInfo {
+  boothType: string;
+  orgType: string;
+  theme: string;
+}
+
+const ORG_TAG_STYLES: Record<string, string> = {
+  club: "bg-[#DDEEFF] text-[#0093E0]",
+  fraternity: "bg-[#E4D7FA] text-[#5B3CB7]",
+  sorority: "bg-[#FFE3D7] text-[#E35A1C]",
+};
+
+const SpecificBoothCard = ({ boothName, cardStatus }: Props) => {
+  const navigate = useNavigate();
+  const setCardStatus = useBoundStore((state) => state.setCardStatus);
+  const isCollapsed = cardStatus === CardStates.COLLAPSED;
+  const booth = (boothData as Record<string, BoothInfo>)[boothName];
+
+  if (!booth) {
+    return null;
+  }
+
+  const renderBadge = (label: string, className: string) => (
+    <span className={`rounded-md px-2 py-1 font-bold text-sm ${className}`}>
+      {label}
+    </span>
+  );
+
+  const renderMiddleButton = () => (
+    <button
+      type="button"
+      className="flex items-center gap-2 rounded-full bg-primary-red px-5 py-2 text-white"
+      onClick={() => {
+        setCardStatus(CardStates.HALF_OPEN);
+        Promise.resolve(navigate("/carnival/booth")).catch(() => undefined);
+      }}
+    >
+      <HiOutlineMap size={16} />
+      <span>View all booth</span>
+    </button>
+  );
+
+  return (
+    <div className="flex min-h-full flex-col">
+      {isCollapsed ? null : (
+        <InfoCardImage url="/imgs/carnival/booth.png" alt={boothName} />
+      )}
+      <div className="mx-3 mt-2">
+        {isCollapsed ? null : (
+          <div className="mb-3 flex gap-2">
+            {renderBadge(booth.boothType, "bg-[#FFE3D7] text-[#E35A1C]")}
+            {renderBadge(
+              booth.orgType,
+              ORG_TAG_STYLES[booth.orgType.toLowerCase()] ??
+                "bg-gray-100 text-gray-700",
+            )}
+          </div>
+        )}
+        <h2 className="leading-tight">{boothName}</h2>
+      </div>
+      <ButtonsRow middleButton={renderMiddleButton()} />
+      {isCollapsed ? null : (
+        <div className="flex-1 px-3 pb-4 text-gray-900">
+          This booth description is placeholder copy for now. It gives us enough
+          text to match the layout while we build the specific booth experience
+          and can be replaced with the real content later.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export { SpecificBoothCard };

--- a/apps/web/src/components/info-cards/wrapper/DraggableSheet.tsx
+++ b/apps/web/src/components/info-cards/wrapper/DraggableSheet.tsx
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/nursery/noFloatingPromises: Fix floating promises */
 import type { PanInfo } from "motion/react";
-import { motion, useAnimation } from "motion/react";
+import { motion, useAnimation, useDragControls } from "motion/react";
 import { useEffect, useMemo, useRef } from "react";
 import { IoIosClose } from "react-icons/io";
 import { useNavigate } from "react-router";
@@ -24,6 +24,7 @@ const DraggableSheet = ({
   // Library hooks
   const navigate = useNavigate();
   const controls = useAnimation();
+  const dragControls = useDragControls();
   const sheetRef = useRef<HTMLDivElement>(null);
 
   // Global state
@@ -49,7 +50,6 @@ const DraggableSheet = ({
     } else {
       setCardStatus(CardStates.COLLAPSED);
     }
-    // setCardStatus(CardStates.COLLAPSED);
   }, [isCardOpen, setCardStatus, floor, focusedFloor, coordinate]);
 
   // updates the snapping when isCardOpen or snapIndex changes
@@ -67,8 +67,6 @@ const DraggableSheet = ({
     controls.set({ y: window.innerHeight });
   }, [controls]);
 
-  /* biome-ignore lint/correctness/useExhaustiveDependencies: re-rendering whenever navigate
-   * changes would lock draggableSheet in Collapsed state */
   useEffect(() => {
     if (
       focusedFloor &&
@@ -139,7 +137,14 @@ const DraggableSheet = ({
   const renderHandle = () => (
     <div className="flex h-12 shrink-0 items-center justify-between px-2">
       <div className="w-8" />
-      <div className="h-[5px] w-14 rounded-full bg-surface-darker-background" />
+      <button
+        type="button"
+        aria-label="Drag sheet"
+        className="cursor-grab rounded-full p-2 active:cursor-grabbing"
+        onPointerDown={(event) => dragControls.start(event)}
+      >
+        <div className="h-[5px] w-14 rounded-full bg-surface-darker-background" />
+      </button>
       <IoIosClose
         title="Close"
         size={32}
@@ -162,12 +167,14 @@ const DraggableSheet = ({
         ref={sheetRef}
         transition={{ duration: 0.5 }}
         drag="y"
+        dragControls={dragControls}
+        dragListener={false}
         onDragEnd={handleDragEnd}
         onDrag={handleDrag}
         className="flex h-dvh flex-col overflow-hidden rounded-t-xl bg-white"
       >
         {renderHandle()}
-        {children}
+        <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
       </motion.div>
     </div>
   );

--- a/apps/web/src/components/info-cards/wrapper/DraggableSheet.tsx
+++ b/apps/web/src/components/info-cards/wrapper/DraggableSheet.tsx
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/nursery/noFloatingPromises: Fix floating promises */
 import type { PanInfo } from "motion/react";
-import { motion, useAnimation, useDragControls } from "motion/react";
+import { motion, useAnimation, useDragControls} from "motion/react";
 import { useEffect, useMemo, useRef } from "react";
 import { IoIosClose } from "react-icons/io";
 import { useNavigate } from "react-router";
@@ -40,7 +40,9 @@ const DraggableSheet = ({
   );
 
   // Custom hooks
-  const { isCardOpen, floor, coordinate, buildingCode } = useLocationParams();
+  const { isCardOpen, floor, coordinate, buildingCode, carnivalEvent } = useLocationParams();
+  const disableBodyDrag =
+    carnivalEvent === "booth" && cardStatus === CardStates.EXPANDED;
 
   // updates the card status when the isCardOpen changes
   // TODO: uncomment once eateries are listed
@@ -135,16 +137,12 @@ const DraggableSheet = ({
   };
 
   const renderHandle = () => (
-    <div className="flex h-12 shrink-0 items-center justify-between px-2">
+    <div 
+      className="flex h-12 shrink-0 items-center justify-between px-2"
+      onPointerDown={(event) => dragControls.start(event)}
+    >
       <div className="w-8" />
-      <button
-        type="button"
-        aria-label="Drag sheet"
-        className="cursor-grab rounded-full p-2 active:cursor-grabbing"
-        onPointerDown={(event) => dragControls.start(event)}
-      >
-        <div className="h-[5px] w-14 rounded-full bg-surface-darker-background" />
-      </button>
+      <div className="h-[5px] w-14 rounded-full bg-surface-darker-background" />
       <IoIosClose
         title="Close"
         size={32}
@@ -168,13 +166,17 @@ const DraggableSheet = ({
         transition={{ duration: 0.5 }}
         drag="y"
         dragControls={dragControls}
-        dragListener={false}
+        dragListener={!disableBodyDrag}
         onDragEnd={handleDragEnd}
         onDrag={handleDrag}
         className="flex h-dvh flex-col overflow-hidden rounded-t-xl bg-white"
       >
         {renderHandle()}
-        <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+        {disableBodyDrag ? (
+          <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+        ) : (
+          children
+        )}
       </motion.div>
     </div>
   );

--- a/apps/web/src/components/info-cards/wrapper/InfoCard.tsx
+++ b/apps/web/src/components/info-cards/wrapper/InfoCard.tsx
@@ -47,7 +47,7 @@ const InfoCard = ({ mapRef }: Props) => {
     }
     if (carnivalEvent === "booth") {
       return {
-        snapPoints: [154, 420, window.innerHeight],
+        snapPoints: [175, 490, window.innerHeight],
         element: () => <BoothCard cardStatus={cardStatus} />,
       };
     }

--- a/apps/web/src/components/info-cards/wrapper/InfoCard.tsx
+++ b/apps/web/src/components/info-cards/wrapper/InfoCard.tsx
@@ -47,7 +47,7 @@ const InfoCard = ({ mapRef }: Props) => {
     }
     if (carnivalEvent === "booth") {
       return {
-        snapPoints: [175, 490, window.innerHeight],
+        snapPoints: [175, 460, window.innerHeight],
         element: () => <BoothCard cardStatus={cardStatus} />,
       };
     }

--- a/apps/web/src/components/info-cards/wrapper/InfoCard.tsx
+++ b/apps/web/src/components/info-cards/wrapper/InfoCard.tsx
@@ -1,6 +1,7 @@
 import { useQueryState } from "nuqs";
 import React from "react";
 import { useNavigate } from "react-router";
+import { BoothCard } from "@/components/booth-cards/BoothCard.tsx";
 import { BuildingCard } from "@/components/info-cards/building-card/BuildingCard.tsx";
 import { CoordinateCard } from "@/components/info-cards/coordinate-card/CoordinateCard.tsx";
 import { NavCardDesktop } from "@/components/info-cards/nav-card-desktop/NavCardDesktop.tsx";
@@ -16,8 +17,10 @@ interface Props {
 
 const InfoCard = ({ mapRef }: Props) => {
   const isMobile = useIsMobile();
-  const { buildingCode, roomName, coordinate } = useLocationParams();
+  const { buildingCode, roomName, coordinate, carnivalEvent } =
+    useLocationParams();
   const isSearchOpen = useBoundStore((state) => state.isSearchOpen);
+  const cardStatus = useBoundStore((state) => state.cardStatus);
 
   // TODO: determine why useNavigationParams causes constant rerenders
   const [src, setSrc] = useQueryState("src");
@@ -40,6 +43,12 @@ const InfoCard = ({ mapRef }: Props) => {
       return {
         snapPoints: [154],
         element: () => <CoordinateCard mapRef={mapRef} />,
+      };
+    }
+    if (carnivalEvent === "booth") {
+      return {
+        snapPoints: [154, 420, window.innerHeight],
+        element: () => <BoothCard cardStatus={cardStatus} />,
       };
     }
     if (roomName) {

--- a/apps/web/src/components/info-cards/wrapper/InfoCard.tsx
+++ b/apps/web/src/components/info-cards/wrapper/InfoCard.tsx
@@ -2,6 +2,7 @@ import { useQueryState } from "nuqs";
 import React from "react";
 import { useNavigate } from "react-router";
 import { BoothCard } from "@/components/booth-cards/BoothCard.tsx";
+import { SpecificBoothCard } from "@/components/booth-cards/SpecificBoothCard.tsx";
 import { BuildingCard } from "@/components/info-cards/building-card/BuildingCard.tsx";
 import { CoordinateCard } from "@/components/info-cards/coordinate-card/CoordinateCard.tsx";
 import { NavCardDesktop } from "@/components/info-cards/nav-card-desktop/NavCardDesktop.tsx";
@@ -17,7 +18,7 @@ interface Props {
 
 const InfoCard = ({ mapRef }: Props) => {
   const isMobile = useIsMobile();
-  const { buildingCode, roomName, coordinate, carnivalEvent } =
+  const { boothName, buildingCode, roomName, coordinate, carnivalEvent } =
     useLocationParams();
   const isSearchOpen = useBoundStore((state) => state.isSearchOpen);
   const cardStatus = useBoundStore((state) => state.cardStatus);
@@ -45,6 +46,14 @@ const InfoCard = ({ mapRef }: Props) => {
         element: () => <CoordinateCard mapRef={mapRef} />,
       };
     }
+    if (carnivalEvent === "booth" && boothName) {
+      return {
+        snapPoints: [175, 470, window.innerHeight],
+        element: () => (
+          <SpecificBoothCard boothName={boothName} cardStatus={cardStatus} />
+        ),
+      };
+    }
     if (carnivalEvent === "booth") {
       return {
         snapPoints: [175, 460, window.innerHeight],
@@ -52,15 +61,12 @@ const InfoCard = ({ mapRef }: Props) => {
       };
     }
     if (roomName) {
-      // TODO: should change based on if has schedule
       return {
         snapPoints: [178, 310, window.innerHeight],
         element: () => <RoomCard />,
       };
     }
     if (buildingCode) {
-      // TODO: should change based on if has food eateries
-      // eateries.length > 0 ? 460 : 288));
       return {
         snapPoints: [154, 288, window.innerHeight],
         element: () => <BuildingCard mapRef={mapRef} />,

--- a/apps/web/src/hooks/useLocationParams.ts
+++ b/apps/web/src/hooks/useLocationParams.ts
@@ -3,12 +3,14 @@ import { useQueryState } from "nuqs";
 import { useNavigate } from "react-router";
 import { toast } from "react-toastify";
 import { $api } from "@/api/client";
+import boothData from "@/assets/carnival/json/booth.json" with { type: "json" };
 import { buildFloorCode, getFloorLevelFromRoomName } from "@/utils/floorUtils";
 
 interface Params {
   buildingCode?: string;
   floor?: string;
   roomName?: string;
+  boothName?: string;
   eventId?: string;
   carnivalEvent?: "booth" | "buggy" | "mobot";
   coordinate?: { latitude: number; longitude: number };
@@ -21,7 +23,9 @@ const useLocationParams = (): Params => {
   const [src, setSrc] = useQueryState("src");
 
   const path = window.location.pathname;
-  const pathSuffix = path.split("/")?.slice(1).join("/") || "";
+  const pathParts = path.split("/");
+  const [, rootSegment, secondarySegment, tertiarySegment] = pathParts;
+  const pathSuffix = pathParts.slice(1).join("/") || "";
   const suffix: string = dst && dst !== pathSuffix ? dst : pathSuffix;
 
   const navigate = useNavigate();
@@ -71,19 +75,45 @@ const useLocationParams = (): Params => {
     return { coordinate: { latitude, longitude }, isCardOpen: !dst };
   }
 
-  if (path.split("/")?.[1] === "events") {
+  if (rootSegment === "events") {
     return {
-      eventId: path.split("/")?.[2],
+      eventId: secondarySegment,
       isCardOpen: true,
     };
   }
 
-  if (path.split("/")?.[1] === "carnival") {
+  if (rootSegment === "carnival") {
+    const carnivalEvent = secondarySegment?.toLowerCase() as
+      | "booth"
+      | "buggy"
+      | "mobot";
+
+    if (carnivalEvent === "booth" && tertiarySegment) {
+      let boothName = "";
+
+      try {
+        boothName = decodeURIComponent(tertiarySegment);
+      } catch {
+        navigate("/carnival/booth");
+        toast.error("Invalid booth name");
+        return { error: "Invalid booth name" };
+      }
+
+      if (!(boothName in boothData)) {
+        navigate("/carnival/booth");
+        toast.error("Invalid booth name");
+        return { error: "Invalid booth name" };
+      }
+
+      return {
+        boothName,
+        carnivalEvent,
+        isCardOpen: true,
+      };
+    }
+
     return {
-      carnivalEvent: path.split("/")?.[2]?.toLowerCase() as
-        | "booth"
-        | "buggy"
-        | "mobot",
+      carnivalEvent,
       isCardOpen: true,
     };
   }
@@ -103,7 +133,7 @@ const useLocationParams = (): Params => {
   }
 
   if (!floor || (building && !building.floors.includes(floor))) {
-    navigate(`/${buildingCode}`);
+    navigate(`/${String(buildingCode)}`);
     toast.error("Invalid floor code");
     return { error: "Invalid floor level" };
   }
@@ -117,7 +147,7 @@ const useLocationParams = (): Params => {
   }
 
   if (!rooms[roomName]) {
-    navigate(`/${buildingCode}-${floor}`);
+    navigate(`/${String(buildingCode)}-${String(floor)}`);
     toast.error("Invalid room code");
     return { error: "Invalid room name" };
   }


### PR DESCRIPTION
Added booth card for mobile users. This includes three draggable card states, booth event card display and a working view all booth button. 

Also changed the draggable sheet file to detect when we are displaying expanded booth card. If that's the case, wrap the children inside a overflow-y-auto div to prevent dragging conflict.